### PR TITLE
Fix homepage url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     long_description=None,
     author=None,
     author_email=None,
-    url='https://github.com/ploomber/ploomber-scaffold',
+    url='https://github.com/ploomber/scaffold',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,


### PR DESCRIPTION
The pypi homepage link is currently broken!  
Simple fix for your next deployment!

Ref ploomber/ploomber#323